### PR TITLE
BUG: Do not build the Docker image with CircleCI.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -6,7 +6,6 @@ dependencies:
   override:
     - docker info
     - docker pull insighttoolkit/cuberille-test
-    - ~/ITKCuberille/test/Docker/build.sh
 
 test:
   override:


### PR DESCRIPTION
The build times out.  The image should be built locally, then pushed to
DockerHub before a pull request.