### PR TITLE
COMP: Address SetInput override virtual warning.

### DIFF
--- a/include/itkCuberilleImageToMeshFilter.h
+++ b/include/itkCuberilleImageToMeshFilter.h
@@ -184,6 +184,7 @@ public:
   itkSetMacro( IsoSurfaceValue, InputPixelType );
 
   /** Accept the input image. */
+  using Superclass::SetInput;
   virtual void SetInput( const InputImageType * inputImage );
 
   /** Get/set interpolate function. */


### PR DESCRIPTION
Addresses:

/home/matt/src/ITK/Modules/Remote/Cuberille/include/itkCuberilleImageToMeshFilter.h: In instantiation of ‘class itk::CuberilleImageToMeshFilter<itk::Image<unsigned char, 3u>, itk::Mesh<unsigned char, 3u>, itk::LinearInterpolateImageFunction<itk::Image<unsigned char, 3u> > >’:
/home/matt/src/ITK/Modules/Remote/Cuberille/test/CuberilleTest01.cxx:123:16:   required from here
/home/matt/src/ITK/Modules/Core/Common/include/itkProcessObject.h:522:16: warning: ‘virtual void itk::ProcessObject::SetInput(const DataObjectIdentifierType&, itk::DataObject*)’ was hidden [-Woverloaded-virtual]
   virtual void SetInput(const DataObjectIdentifierType & key, DataObject *input);
                ^
In file included from /home/matt/src/ITK/Modules/Remote/Cuberille/include/itkCuberilleImageToMeshFilter.h:347:0,
                 from /home/matt/src/ITK/Modules/Remote/Cuberille/test/CuberilleTest01.cxx:27:
/home/matt/src/ITK/Modules/Remote/Cuberille/include/itkCuberilleImageToMeshFilter.hxx:53:1: warning:   by ‘void itk::CuberilleImageToMeshFilter<TInputImage, TOutputMesh, TInterpolator>::SetInput(const InputImageType*) [with TInputImage = itk::Image<unsigned char, 3u>; TOutputMesh = itk::Mesh<unsigned char, 3u>; TInterpolator = itk::LinearInterpolateImageFunction<itk::Image<unsigned char, 3u> >; itk::CuberilleImageToMeshFilter<TInputImage, TOutputMesh, TInterpolator>::InputImageType = itk::Image<unsigned char, 3u>]’ [-Woverloaded-virtual]
 CuberilleImageToMeshFilter<TInputImage,TOutputMesh,TInterpolator>
 ^