### PR TITLE
Fixing appearance of Not-A-Number values when gradient is 0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.9)
 project(Cuberille)
 
 if(NOT ITK_SOURCE_DIR)
-  find_package(ITK REQUIRED)
+  find_package(ITK 4.10 REQUIRED)
   list(APPEND CMAKE_MODULE_PATH ${ITK_CMAKE_DIR})
   include(ITKModuleExternal)
 else()

--- a/include/itkCuberilleImageToMeshFilter.hxx
+++ b/include/itkCuberilleImageToMeshFilter.hxx
@@ -450,6 +450,10 @@ CuberilleImageToMeshFilter<TInputImage,TOutputMesh,TInterpolator>
     {
     // Compute normal vector
     normal = m_GradientInterpolator->Evaluate( vertex );
+    if (normal.GetSquaredNorm() == 0)
+      {
+      break;
+      }
     normal.Normalize();
 
     // Compute whether vertex is close enough to iso-surface value

--- a/include/itkCuberilleImageToMeshFilter.hxx
+++ b/include/itkCuberilleImageToMeshFilter.hxx
@@ -355,7 +355,10 @@ CuberilleImageToMeshFilter<TInputImage,TOutputMesh,TInterpolator>
     {
     // Compute normal vector
     GradientPixelType normal = m_GradientInterpolator->Evaluate(vertex);
-    normal.Normalize();
+    if (normal.Normalize() == 0.0) //old norm was zero
+      {
+      break;
+      }
 
     // Step along both directions of normal
     for ( i=0; i< InputImageType::ImageDimension; ++i )
@@ -407,7 +410,10 @@ CuberilleImageToMeshFilter<TInputImage,TOutputMesh,TInterpolator>
 
   // Compute normal vector
   normal = m_GradientInterpolator->Evaluate( vertex );
-  normal.Normalize();
+  if (normal.Normalize() == 0.0) //old norm was zero
+    {
+    break;
+    }
 
   // Search on both sides of the line
   for ( sign = -1.0; sign <= 1.0; sign += 2.0 )
@@ -450,11 +456,10 @@ CuberilleImageToMeshFilter<TInputImage,TOutputMesh,TInterpolator>
     {
     // Compute normal vector
     normal = m_GradientInterpolator->Evaluate( vertex );
-    if (normal.GetSquaredNorm() == 0)
+    if (normal.Normalize() == 0.0) //old norm was zero
       {
       break;
       }
-    normal.Normalize();
 
     // Compute whether vertex is close enough to iso-surface value
     value = m_Interpolator->Evaluate(vertex);


### PR DESCRIPTION
The fix could have been a bit more elegant of Normalize() returned the previous norm.