### PR TITLE
BUG: Instatiate itkCuberilleImageToMeshFilter

### DIFF
--- a/wrapping/itkCuberilleImageToMeshFilter.wrap
+++ b/wrapping/itkCuberilleImageToMeshFilter.wrap
@@ -1,7 +1,9 @@
-itk_wrap_class("itk::CuberilleImageToMeshFilter" POINTER)
+itk_wrap_class("itk::CuberilleImageToMeshFilter" POINTER_WITH_2_SUPERCLASSES)
+UNIQUE(types "${WRAP_ITK_REAL};D")
 foreach(d ${ITK_WRAP_IMAGE_DIMS})
-  foreach(t ${ITK_WRAP_SCALAR})
-    itk_wrap_template("${ITKM_I${t}${d}}M${ITKM_D}${d}$" "${ITKT_I${t}${d}}, itk::Mesh< ${ITKT_D}, ${d} >")
+  foreach(t ${types})
+    itk_wrap_template("${ITKM_I${t}${d}}M${ITKM_${t}}${d}DSM${ITKM_${t}}${d}${d}${ITKM_F}${ITKM_F}" 
+                      "${ITKT_I${t}${d}}, itk::Mesh< ${ITKT_${t}},${d},itk::DefaultStaticMeshTraits<${ITKT_${t}},${d},${d},${ITKT_F},${ITKT_F} > >")
   endforeach()
 endforeach()
 itk_end_wrap_class()


### PR DESCRIPTION
The old wrapping didn't work because the .wrap file did not include the superclass or fully specify the template.