### PR TITLE
COMP: Move ITK_DISALLOW_COPY_AND_ASSIGN calls to public section.

### DIFF
--- a/include/itkCuberilleImageToMeshFilter.h
+++ b/include/itkCuberilleImageToMeshFilter.h
@@ -114,6 +114,8 @@ template < class TInputImage, class TOutputMesh, class TInterpolator=itk::Linear
 class CuberilleImageToMeshFilter : public ImageToMeshFilter< TInputImage, TOutputMesh >
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(CuberilleImageToMeshFilter);
+
   /** Standard "Self" type alias. */
   using Self = CuberilleImageToMeshFilter;
   using Superclass = ImageToMeshFilter< TInputImage, TOutputMesh >;
@@ -240,8 +242,6 @@ protected:
   void GenerateOutputInformation() override{ }; // do nothing
 
 private:
-  ITK_DISALLOW_COPY_AND_ASSIGN(CuberilleImageToMeshFilter);
-
   /** \class VertexLookupNode A private class containing lookup details for vertices.
    *  \ingroup Cuberille */
   class VertexLookupNode


### PR DESCRIPTION
Move `ITK_DISALLOW_COPY_AND_ASSIGN` calls to public section following
the discussion in
https://discourse.itk.org/t/noncopyable

If legacy (pre-macro) copy and assing methods existed, subsitute them
for the `ITK_DISALLOW_COPY_AND_ASSIGN` macro.