### PR TITLE
BUG: Prevent Non-Manifold Geometry

### DIFF
--- a/itk-module.cmake
+++ b/itk-module.cmake
@@ -20,6 +20,7 @@ itk_module(Cuberille
     ITKImageFunction
     ITKImageGradient
     ITKMesh
+    ITKConnectedComponents
   TEST_DEPENDS
     ITKTestKernel
     ITKQuadEdgeMesh

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -49,7 +49,7 @@ add_test(
     ${DATA_DIR}/blob2.mha
     ${ITK_TEST_OUTPUT_DIR}/blob2-01.vtk
     200   # Iso-surface value
-    14    # Expected number of points
+    16    # Expected number of points
     12    # Expected number of cells
     0     # Generate triangle faces
     0     # Project vertices to iso-surface
@@ -65,7 +65,7 @@ add_test(
     ${DATA_DIR}/blob3.mha
     ${ITK_TEST_OUTPUT_DIR}/blob3-01.vtk
     200   # Iso-surface value
-    122   # Expected number of points
+    216   # Expected number of points
     180   # Expected number of cells
     0     # Generate triangle faces
     0     # Project vertices to iso-surface
@@ -97,7 +97,7 @@ add_test(
     ${DATA_DIR}/marschnerlobb.mha
     ${ITK_TEST_OUTPUT_DIR}/marschnerlobb-01.vtk
     55    # Iso-surface value
-    20524 # Expected number of points
+    22106 # Expected number of points
     22104 # Expected number of cells
     0     # Generate triangle faces
     1     # Project vertices to iso-surface
@@ -177,7 +177,7 @@ add_test(
     ${DATA_DIR}/neghip.mha
     ${ITK_TEST_OUTPUT_DIR}/neghip-01.vtk
     55    # Iso-surface value
-    15146 # Expected number of points
+    15162 # Expected number of points
     15136 # Expected number of cells
     0     # Generate triangle faces
     0     # Project vertices to iso-surface
@@ -193,7 +193,7 @@ add_test(
     ${DATA_DIR}/neghip.mha
     ${ITK_TEST_OUTPUT_DIR}/neghip-02.vtk
     55    # Iso-surface value
-    15146 # Expected number of points
+    15162 # Expected number of points
     15136 # Expected number of cells
     0     # Generate triangle faces
     1     # Project vertices to iso-surface
@@ -209,7 +209,7 @@ add_test(
     ${DATA_DIR}/neghip.mha
     ${ITK_TEST_OUTPUT_DIR}/neghip-03.vtk
     55    # Iso-surface value
-    15146 # Expected number of points
+    15162 # Expected number of points
     30272 # Expected number of cells
     1     # Generate triangle faces
     1     # Project vertices to iso-surface

--- a/test/CuberilleTest01.cxx
+++ b/test/CuberilleTest01.cxx
@@ -156,6 +156,16 @@ int CuberilleTest01 (int argc, char * argv [] )
   ITK_EXERCISE_BASIC_OBJECT_METHODS( cuberille, CuberilleImageToMeshFilter,
     ImageToMeshFilter );
 
+  // How long does it take to pre-calculate the array labels array?
+
+  itk::TimeProbe labelsArrayTimer;
+
+  labelsArrayTimer.Start();
+  cuberille->CalculateLabelsArray();
+  labelsArrayTimer.Stop();
+
+  std::cout << "Time to calculate labels array: " << labelsArrayTimer.GetMean() << std::endl;
+
   cuberille->SetInput( input );
 
   cuberille->SetIsoSurfaceValue( isoSurfaceValue );


### PR DESCRIPTION
This patch addresses a long-standing issue in the Cuberille module
which frequently prevented its use with itk::QuadEdgeMesh, due a
number of cases in which this filter produces non-manifold geometry.
This patch determines, for each 2x2x2 neighborhood surrounding a
vertex, how many face-connected components N are present, and replicates
the relevant vertex N times.  Then, in the vertex map, the bitmask
and the position of the pixel index is used to determine which vertex
to select in the construction of each face.