### PR TITLE
BUG: Fix URL in License File

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ ITKCuberille
     :alt: PyPI
 
 .. image:: https://img.shields.io/badge/License-Apache%202.0-blue.svg
-    :target: https://github.com/InsightSoftwareConsortium/ITKCuberille/blob/master/LICENSE)
+    :target: https://github.com/InsightSoftwareConsortium/ITKCuberille/blob/master/LICENSE
     :alt: License
 
 Overview


### PR DESCRIPTION
Fixes 404 error due to extraneous parenthesis.