### PR TITLE
ENH: Improve Code Coverage

### DIFF
--- a/test/CuberilleTest02.cxx
+++ b/test/CuberilleTest02.cxx
@@ -28,8 +28,9 @@
 
 const unsigned int Dimension = 3;
 using TPixel = unsigned char;
+using TCoordinate = double;
 using TImage = itk::Image<TPixel, Dimension>;
-using TMesh = itk::Mesh<double, Dimension>;
+using TMesh = itk::Mesh<TCoordinate, Dimension>;
 using TImageToMesh = itk::CuberilleImageToMeshFilter<TImage, TMesh>;
 using TInterp = itk::NearestNeighborInterpolateImageFunction<TImage>;
 

--- a/test/CuberilleTest03.cxx
+++ b/test/CuberilleTest03.cxx
@@ -29,8 +29,9 @@
 
 const unsigned int Dimension = 3;
 using TPixel = unsigned char;
+using TCoordinate = double;
 using TImage = itk::Image<TPixel, Dimension>;
-using TMesh = itk::Mesh<double, Dimension>;
+using TMesh = itk::Mesh<TCoordinate, Dimension>;
 using TImageToMesh = itk::CuberilleImageToMeshFilter<TImage, TMesh>;
 using TInterp = itk::NearestNeighborInterpolateImageFunction<TImage>;
 using TTriangleHelper = itk::TriangleHelper<typename TMesh::PointType>;


### PR DESCRIPTION
This patch templatizes the primary test over the image and mesh type,
so that it can be run on both Mesh and QuadEdgeMesh.  Additionally,
ITK_TEST_SET_GET_BOOLEAN is preferred over ITK_TEST_SET_GET_VALUE
where appropriate.  Finally, consistent pixel and coordinate types
are used throughout. Line coverage is 99.8%, unchanged from prior to
the patch.  Function coverage is 98.0%, improved from 71.4% prior to
the patch.