### PR TITLE
ENH: modify wrapping to produce float mesh coordinate type

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -1,6 +1,14 @@
 name: Build, test, package
 
-on: [push,pull_request]
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
+  pull_request:
+    branches:
+      - main
 
 jobs:
   cxx-build-workflow:

--- a/.github/workflows/clang-format-linter.yml
+++ b/.github/workflows/clang-format-linter.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 1
     - uses: InsightSoftwareConsortium/ITKClangFormatLinterAction@master

--- a/wrapping/itkCuberilleImageToMeshFilter.wrap
+++ b/wrapping/itkCuberilleImageToMeshFilter.wrap
@@ -2,8 +2,9 @@ itk_wrap_class("itk::CuberilleImageToMeshFilter" POINTER_WITH_2_SUPERCLASSES)
 UNIQUE(types "${WRAP_ITK_SCALAR}")
 foreach(d ${ITK_WRAP_IMAGE_DIMS})
   foreach(t ${types})
-    itk_wrap_template("${ITKM_I${t}${d}}M${ITKM_${t}}${d}"
-                      "${ITKT_I${t}${d}}, itk::Mesh< ${ITKT_${t}},${d} >, itk::InterpolateImageFunction< ${ITKT_I${t}${d}}, ${ITKT_D} >")
+    # in all cases use float for mesh coordinates and double for interpolator's internal coordinates
+    itk_wrap_template("${ITKM_I${t}${d}}M${ITKM_F${d}}"
+                      "${ITKT_I${t}${d}}, itk::Mesh< float,${d} >, itk::InterpolateImageFunction< ${ITKT_I${t}${d}}, double >")
   endforeach()
 endforeach()
 itk_end_wrap_class()


### PR DESCRIPTION
When used with unsigned char input images, which is the common case, the produced mesh would use UC as coordinate type. This would not only cause a massive loss in precision and range, but is not wrapped with itk::Mesh class thus causing runtime error:

   itk.meshwrite(mesh, file_path)
     ...
itk.support.extras.TemplateTypeError: itk.MeshFileWriter is not wrapped for input type `itk.Mesh[itk.UC,3]`. To limit the size of the package, only a limited number of types are available in ITK Python.
...
Supported input types:
itk.Mesh[itk.F,2]
itk.Mesh[itk.D,2]
itk.Mesh[itk.F,3]
itk.Mesh[itk.D,3]